### PR TITLE
Fix missing resource instance key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "alicloud_vpc" "vpc" {
 // According to the vswitch cidr blocks to launch several vswitches
 resource "alicloud_vswitch" "vswitches" {
   count             = "${length(var.vswitch_cidrs)}"
-  vpc_id            = "${var.vpc_id != "" ? var.vpc_id : alicloud_vpc.vpc.id}"
+  vpc_id            = "${var.vpc_id != "" ? var.vpc_id : alicloud_vpc.vpc[0].id}"
   cidr_block        = "${element(var.vswitch_cidrs, count.index)}"
   availability_zone = "${element(var.availability_zones, count.index) != "" ? element(var.availability_zones, count.index) : lookup(data.alicloud_zones.default.zones[format("%d", length(data.alicloud_zones.default.zones) < 2 ? 0 : count.index%length(data.alicloud_zones.default.zones))], "id")}"
   name              = "${length(var.vswitch_cidrs) < 2 ? var.vswitch_name : format("%s_%s", var.vswitch_name, format(var.number_format, count.index+1))}"
@@ -31,7 +31,7 @@ resource "alicloud_vswitch" "vswitches" {
 // According to the destination cidr block to launch a new route entry
 resource "alicloud_route_entry" "route_entry" {
   count                 = "${length(var.destination_cidrs)}"
-  route_table_id        = "${var.route_table_id != "" ? var.route_table_id : var.vpc_id == "" ? alicloud_vpc.vpc.route_table_id : ""}"
+  route_table_id        = "${var.route_table_id != "" ? var.route_table_id : var.vpc_id == "" ? alicloud_vpc.vpc[0].route_table_id : ""}"
   destination_cidrblock = "${var.destination_cidrs[count.index]}"
   nexthop_type          = "Instance"
   nexthop_id            = "${var.nexthop_ids[count.index]}"


### PR DESCRIPTION
For terraform >= 0.12.5, terraform will complain about missing instance key:

```
Error: Missing resource instance key

  on .terraform/modules/vpc/terraform-alicloud-modules-terraform-alicloud-vpc-23a6abe/main.tf line 24, in resource "alicloud_vswitch" "vswitches":
  24:   vpc_id            = "${var.vpc_id != "" ? var.vpc_id : alicloud_vpc.vpc.id}"

Because alicloud_vpc.vpc has "count" set, its attributes must be accessed on
specific instances.

For example, to correlate with indices of a referring resource, use:
    alicloud_vpc.vpc[count.index]
```

This PR addresses the problem by providing an index key (supposedly 0).