### PR TITLE
Update attribute names to avoid deprecation warnings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ provider "alicloud" {
 // If there is not specifying vpc_id, the module will launch a new vpc
 resource "alicloud_vpc" "vpc" {
   count             = var.vpc_id != "" ? 0 : var.create ? 1 : 0
-  name              = var.vpc_name
+  vpc_name          = var.vpc_name
   cidr_block        = var.vpc_cidr
   resource_group_id = var.resource_group_id
   description       = var.vpc_description
@@ -26,8 +26,8 @@ resource "alicloud_vswitch" "vswitches" {
   count             = local.create_sub_resources ? length(var.vswitch_cidrs) : 0
   vpc_id            = var.vpc_id != "" ? var.vpc_id : concat(alicloud_vpc.vpc.*.id, [""])[0]
   cidr_block        = var.vswitch_cidrs[count.index]
-  availability_zone = element(var.availability_zones, count.index)
-  name              = length(var.vswitch_cidrs) > 1 || var.use_num_suffix ? format("%s%03d", var.vswitch_name, count.index + 1) : var.vswitch_name
+  zone_id           = element(var.availability_zones, count.index)
+  vswitch_name      = length(var.vswitch_cidrs) > 1 || var.use_num_suffix ? format("%s%03d", var.vswitch_name, count.index + 1) : var.vswitch_name
   description       = var.vswitch_description
   tags = merge(
     {


### PR DESCRIPTION
This pull request updates the resource attribute names to avoid deprectation warnings from the provider:
```
╷
│ Warning: "name": [DEPRECATED] Field 'name' has been deprecated from provider version 1.119.0. New field 'vpc_name' instead.
│
│   with module.vpc.alicloud_vpc.vpc,
│   on .terraform/modules/vpc/main.tf line 10, in resource "alicloud_vpc" "vpc":
│   10: resource "alicloud_vpc" "vpc" {
│
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: "name": [DEPRECATED] Field 'name' has been deprecated from provider version 1.119.0. New field 'vswitch_name' instead.
│
│   with module.vpc.alicloud_vswitch.vswitches,
│   on .terraform/modules/vpc/main.tf line 25, in resource "alicloud_vswitch" "vswitches":
│   25: resource "alicloud_vswitch" "vswitches" {
│
╵
╷
│ Warning: "availability_zone": [DEPRECATED] Field 'availability_zone' has been deprecated from provider version 1.119.0. New field 'zone_id' instead.
│
│   with module.vpc.alicloud_vswitch.vswitches,
│   on .terraform/modules/vpc/main.tf line 25, in resource "alicloud_vswitch" "vswitches":
│   25: resource "alicloud_vswitch" "vswitches" {
│
╵
```