### PR TITLE
Do not use the deprecated field `name` for VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "alicloud_vswitch" "vswitches" {
   vpc_id            = var.vpc_id != "" ? var.vpc_id : concat(alicloud_vpc.vpc.*.id, [""])[0]
   cidr_block        = var.vswitch_cidrs[count.index]
   availability_zone = element(var.availability_zones, count.index)
-  name              = length(var.vswitch_cidrs) > 1 || var.use_num_suffix ? format("%s%03d", var.vswitch_name, count.index + 1) : var.vswitch_name
+  vswitch_name      = length(var.vswitch_cidrs) > 1 || var.use_num_suffix ? format("%s%03d", var.vswitch_name, count.index + 1) : var.vswitch_name
   description       = var.vswitch_description
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 // If there is not specifying vpc_id, the module will launch a new vpc
 resource "alicloud_vpc" "vpc" {
   count             = var.vpc_id != "" ? 0 : var.create ? 1 : 0
-  name              = var.vpc_name
+  vpc_name          = var.vpc_name
   cidr_block        = var.vpc_cidr
   resource_group_id = var.resource_group_id
   description       = var.vpc_description

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    alicloud = {
+      source  = "aliyun/alicloud"
+      version = ">= 1.119.0"
+    }
+  }
 }


### PR DESCRIPTION
See: https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/vpc#vpc_name